### PR TITLE
change View.propTypes -> ViewPropTypes

### DIFF
--- a/example/src/components/debug.js
+++ b/example/src/components/debug.js
@@ -1,10 +1,12 @@
 import React from "react";
+import PropTypes from 'prop-types';
+
 import {
 	View,
 	Text
 } from "react-native";
-import { 
-	MediaQuery, 
+import {
+	MediaQuery,
 	MediaQueryDebug,
 	MediaQueryDecorator
 } from "react-native-responsive";
@@ -14,7 +16,7 @@ import {
 }, true)
 class Debug extends React.Component {
 	static propTypes = {
-		consoleDebug: React.PropTypes.bool.isRequired
+		consoleDebug: PropTypes.bool.isRequired
 	};
 	static defaultProps = {
 		consoleDebug: false

--- a/example/src/components/detail.js
+++ b/example/src/components/detail.js
@@ -3,7 +3,8 @@ import React, {
 } from "react";
 import {
 	View,
-	Text
+	Text,
+    ViewPropType
 } from "react-native";
 
 const Detail = (props) => {
@@ -13,7 +14,7 @@ const Detail = (props) => {
 				{props.children}
 			</View>
 		);
-	
+
 	return (
 		<View style={props.style}>
 			<Text> No Item selected </Text>
@@ -22,7 +23,7 @@ const Detail = (props) => {
 };
 
 Detail.propTypes = {
-	...View.propTypes,
+	...ViewPropType,
 	children: PropTypes.node.isRequired
 };
 

--- a/example/src/components/detail.js
+++ b/example/src/components/detail.js
@@ -4,7 +4,7 @@ import React, {
 import {
 	View,
 	Text,
-    ViewPropType
+	ViewPropType
 } from "react-native";
 
 const Detail = (props) => {

--- a/lib/components/debug.js
+++ b/lib/components/debug.js
@@ -3,14 +3,15 @@ import React, {
 } from "react";
 import {
 	View,
-	Text
+	Text,
+    ViewPropType
 } from "react-native";
 import { Device } from "../models";
 
 class Debug extends Component {
 	static displayName = "MediaQueryDebug";
 	static propTypes = {
-		...View.propTypes
+		...ViewPropType
 	};
 
 	constructor(props) {

--- a/lib/components/debug.js
+++ b/lib/components/debug.js
@@ -4,7 +4,7 @@ import React, {
 import {
 	View,
 	Text,
-    ViewPropType
+	ViewPropType
 } from "react-native";
 import { Device } from "../models";
 

--- a/lib/components/query.js
+++ b/lib/components/query.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { Device } from "../models";
 import { MediaQueryPropTypes } from "../apis";
 
@@ -6,16 +7,16 @@ class Query extends React.Component {
 	static displayName = "MediaQuery";
 	static propTypes = {
 		children: MediaQueryPropTypes.childrenValidator,
-		debug: React.PropTypes.bool,
-		deviceWidth: React.PropTypes.number,
-		minDeviceWidth: React.PropTypes.number,
-		maxDeviceWidth: React.PropTypes.number,
-		deviceHeight: React.PropTypes.number,
-		minDeviceHeight: React.PropTypes.number,
-		maxDeviceHeight: React.PropTypes.number,
-		devicePixelRatio: React.PropTypes.number,
-		minDevicePixelRatio: React.PropTypes.number,
-		maxDevicePixelRatio: React.PropTypes.number
+		debug: PropTypes.bool,
+		deviceWidth: PropTypes.number,
+		minDeviceWidth: PropTypes.number,
+		maxDeviceWidth: PropTypes.number,
+		deviceHeight: PropTypes.number,
+		minDeviceHeight: PropTypes.number,
+		maxDeviceHeight: PropTypes.number,
+		devicePixelRatio: PropTypes.number,
+		minDevicePixelRatio: PropTypes.number,
+		maxDevicePixelRatio: PropTypes.number
 	};
 	static defaultProps = {
 		debug: false
@@ -37,7 +38,7 @@ class Query extends React.Component {
 	render() {
 		if(this.state.isVisible)
 			return this.props.children;
-			
+
 		return null;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "adib"
   ],
   "author": "Ayoub Adib <ayoub.development@gmail.com>",
+  "contributors": [
+    "Kohki Makimoto <kohki.makimoto@gmail.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/ayoubdev/react-native-responsive/issues"


### PR DESCRIPTION
I'm using react-native-responsive with RN0.44, and I got a warning 

```
Warning: View.propTypes has been deprecated and will be removed in a future version of ReactNative. Use ViewPropTypes instead.
```

Please merge it to suppress the warning.
Thanks for your useful package. 😄 