### PR TITLE
Fix require cycle warning

### DIFF
--- a/lib/models/device.js
+++ b/lib/models/device.js
@@ -1,5 +1,5 @@
 import Model from "./model.js";
-import { DeviceUtil } from "../apis";
+import { DeviceUtil } from "../apis/utils";
 
 class Device extends Model {
 	constructor(expected) {

--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -1,4 +1,4 @@
-import { CommonUtil } from "../apis";
+import { CommonUtil } from "../apis/utils";
 
 class Model {
 	constructor(expected) {


### PR DESCRIPTION
I got a warning message `Require cycle are allowed, but can result in uninitialized values.` with react-native-responsive v1.0.2

<img width="949" alt="image-for-react-native-responsive" src="https://user-images.githubusercontent.com/761462/59818017-209e5600-935d-11e9-9c5f-d9b8873e4fea.png">

This PR fixes the warning.

